### PR TITLE
add 0x04 footer variation

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,4 +1,4 @@
-use crate::{channels_parsing, SbusError, SBUS_FOOTER, SBUS_FRAME_LENGTH, SBUS_HEADER};
+use crate::{channels_parsing, SbusError, SBUS_FOOTER, SBUS_FOOTER_2, SBUS_FRAME_LENGTH, SBUS_HEADER};
 
 /// Represents a complete SBUS packet with channel data and flags
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -36,7 +36,7 @@ impl SbusPacket {
         // Check header and footer
         if header != SBUS_HEADER {
             Err(SbusError::InvalidHeader(header))
-        } else if frame_buf[SBUS_FRAME_LENGTH - 1] != SBUS_FOOTER {
+        } else if footer != SBUS_FOOTER &&  footer & 0x0F != SBUS_FOOTER_2 {
             Err(SbusError::InvalidFooter(footer))
         } else {
             Ok(())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,6 +27,7 @@ trait Sealed {}
 pub const SBUS_HEADER: u8 = 0x0F;
 /// The SBus Frame footer should end with a zero byte `0x00` (0 decimal).
 pub const SBUS_FOOTER: u8 = 0x00;
+pub const SBUS_FOOTER_2: u8 = 0x04;
 /// The SBus Frame length
 pub const SBUS_FRAME_LENGTH: usize = 25;
 /// The number of channels in a SBus Frame.


### PR DESCRIPTION
Add `SBUS_FOOTER_2` variation to fix sbus footer byte not being recognised.

This is inline with the [bolderflight arduino sbus library](https://github.com/bolderflight/sbus/blob/003c5c33a75fc3e54dee90caff1f84e0fb9a5666/src/sbus.cpp#L110)