### PR TITLE
fix sbus2 footer variations in StreamingParser

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,6 +1,4 @@
-use crate::{
-    channels_parsing, SbusError, SBUS_FOOTER, SBUS_FOOTER_2, SBUS_FRAME_LENGTH, SBUS_HEADER,
-};
+use crate::{channels_parsing, valid_footer, SbusError, SBUS_FRAME_LENGTH, SBUS_HEADER};
 
 /// Represents a complete SBUS packet with channel data and flags
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -38,7 +36,7 @@ impl SbusPacket {
         // Check header and footer
         if header != SBUS_HEADER {
             Err(SbusError::InvalidHeader(header))
-        } else if footer != SBUS_FOOTER && footer & 0x0F != SBUS_FOOTER_2 {
+        } else if !valid_footer(footer) {
             Err(SbusError::InvalidFooter(footer))
         } else {
             Ok(())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -28,6 +28,11 @@ pub const SBUS_HEADER: u8 = 0x0F;
 /// The SBus Frame footer should end with a zero byte `0x00` (0 decimal).
 pub const SBUS_FOOTER: u8 = 0x00;
 pub const SBUS_FOOTER_2: u8 = 0x04;
+
+pub const fn valid_footer(footer: u8) -> bool {
+    footer == SBUS_FOOTER || footer & 0x0F == SBUS_FOOTER_2
+}
+
 /// The SBus Frame length
 pub const SBUS_FRAME_LENGTH: usize = 25;
 /// The number of channels in a SBus Frame.

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,5 +1,5 @@
 //! Streaming parser for SBUS frames that can handle partial data
-use crate::{SbusError, SbusPacket, SBUS_FOOTER, SBUS_FRAME_LENGTH, SBUS_HEADER};
+use crate::{valid_footer, SbusError, SbusPacket, SBUS_FRAME_LENGTH, SBUS_HEADER};
 
 /// A streaming parser that accumulates bytes until a complete SBUS frame is decoded
 ///
@@ -100,7 +100,7 @@ impl StreamingParser {
         // Check if we have a complete frame
         if self.pos == SBUS_FRAME_LENGTH {
             // Validate footer
-            if self.buffer[SBUS_FRAME_LENGTH - 1] == SBUS_FOOTER {
+            if valid_footer(self.buffer[SBUS_FRAME_LENGTH - 1]) {
                 // Valid frame!
                 match SbusPacket::from_array(&self.buffer) {
                     Ok(packet) => {
@@ -191,7 +191,7 @@ impl<'a> Iterator for StreamingIterator<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{pack_channels, CHANNEL_COUNT, CHANNEL_MAX};
+    use crate::{pack_channels, CHANNEL_COUNT, CHANNEL_MAX, SBUS_FOOTER};
     extern crate alloc;
     use alloc::vec::Vec;
 


### PR DESCRIPTION
Hi,

I like the new `StreamingParser` but it isn't compatible with sbus2 footer bytes which have a variation.
I have added a `valid_footer` function and use it to check if the footer is valid in `SbusPacket` and `StreamingParser`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a public helper to validate frame footers, available for consumers needing explicit validation.

- Refactor
  - Unified footer validation across parsing and streaming paths for consistent behavior and reduced duplication.

- Tests
  - Updated tests to align with the new centralized footer validation logic.

No changes to existing public types or method signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->